### PR TITLE
Fix multiscale hangups

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -2404,21 +2404,6 @@ void engine_init_particles(struct engine *e, int flag_entropy_ICs,
 
   /* Zero the list of cells that have had their time-step updated */
   bzero(e->s->cells_top_updated, e->s->nr_cells * sizeof(char));
-  //  for (int i = 0; i < e->sched.nr_tasks; i++){
-  //	  struct task *tmp_t = &e->sched.tasks[i];
-  //	  if(tmp_t->subtype == task_subtype_density){
-  //		if(tmp_t->skip == 1)error("inactive density task");
-  //	  }
-  //	  if(tmp_t->subtype == task_subtype_force){
-  //		if(tmp_t->skip == 1)error("inactive force task");
-  //	  }
-  //	  if(tmp_t->subtype == task_subtype_gpu_pack_d){
-  //		if(tmp_t->skip == 1)error("inactive pack task");
-  //	  }
-  //	  if(tmp_t->subtype == task_subtype_gpu_unpack_d){
-  //	    if(tmp_t->skip == 1)error("inactive unpack task");
-  //	  }
-  //  }
 
   /* Run the 0th time-step */
   TIMER_TIC2;

--- a/src/queue.c
+++ b/src/queue.c
@@ -143,7 +143,7 @@ void queue_get_incoming(struct queue *q) {
     /* Re-heap by bubbling up the new (last) element. */
     queue_bubble_up(q, q->count - 1);
 
-#ifdef SWIFT_DEBUG_CHECK
+#ifdef SWIFT_DEBUG_CHECKS
     /* Check the queue's consistency. */
     for (int k = 1; k < q->count; k++)
       if (entries[(k - 1) / 2].weight < entries[k].weight)

--- a/src/runner_doiact_functions_hydro_gpu.h
+++ b/src/runner_doiact_functions_hydro_gpu.h
@@ -493,61 +493,155 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
   int tind = md->tasks_in_list;
 
 #ifdef SWIFT_DEBUG_CHECKS
-  if (tind >= md->params.pack_size)
-    error("Writing out of task_list array bounds: %d/%d",
-          tind, md->params.pack_size);
+  /* Check whether we'll be writing out of bounds. Allow for the special case
+   * where we find a task with zero leaf cell pair interactions (see
+   * explanation further below) */
+  if (tind > md->params.pack_size ||
+      ((tind == md->params.pack_size && md->task_n_leaves != 0 )))
+    error(
+        "Runner %d: Writing out of task_list array bounds: "
+        "%d/%d, n_leaves_packed=%d, task_n_leaves=%d",
+        r->id, tind, md->params.pack_size, md->n_leaves_packed,
+        md->task_n_leaves);
 #endif
 
-  /* Keep track of index of first leaf cell pairs in lists per super-level pair
-   * task in case we are packing more than one super-level task into this
-   * buffer. Note that md->n_leaves has not been yet updated to contain this
-   * task's leaf cell pair count.*/
-  task_first_packed_leaf[tind] = md->n_leaves;
-  /* Same for the first particle index in particle buffers */
-  md->task_first_packed_part[tind] = md->count_parts;
+  /* Update the bookkeeping, but only if this task has leaf cell pairs which
+   * interact with each other or if we're launching leftovers. */
+  if (md->task_n_leaves > 0 || md->launch_leftovers) {
 
-  /* Get pointer to task. Needed to enqueue dependencies after we're done. */
-  md->task_list[tind] = t;
+    /* Keep track of index of first leaf cell pairs in lists per super-level pair
+     * task in case we are packing more than one super-level task into this
+     * buffer. */
+    task_first_packed_leaf[tind] = md->n_leaves_packed;
+    /* Same for the first particle index in particle buffers */
+    md->task_first_packed_part[tind] = md->count_parts;
 
-  /* Increment how many tasks we've accounted for */
-  md->tasks_in_list++;
+    /* Get pointer to task. Needed to enqueue dependencies after we're done. */
+    md->task_list[tind] = t;
+
+    /* Increment how many tasks we've accounted for */
+    md->tasks_in_list++;
 
 #ifdef SWIFT_DEBUG_CHECKS
-  /* At this point, md->n_leaves_packed and md->n_leaves should be identical.
-   * They will diverge during the main offloading loop below, but if they
-   * aren't equal here, then something's wrong with our bookkeeping. */
-  if (md->n_leaves_packed != md->n_leaves)
-    error("Found leaf_pairs_packed=%d and n_leaves=%d", md->n_leaves_packed,
-          md->n_leaves);
+    /* At this point, md->n_leaves_packed and md->n_leaves should be identical.
+     * They will diverge during the main offloading loop below, but if they
+     * aren't equal here, then something's wrong with our bookkeeping. */
+    if (md->n_leaves_packed != md->n_leaves)
+      error("Found leaf_pairs_packed=%d and n_leaves=%d", md->n_leaves_packed,
+            md->n_leaves);
 #endif
 
-  /* Update the total number of leaf interactions we found through the
-   * recursion. */
-  md->n_leaves += md->task_n_leaves;
+    /* Update the total number of leaf interactions we found through the
+     * recursion. */
+    md->n_leaves += md->task_n_leaves;
+  }
+
+  /* Any work here? */
+  if (md->task_n_leaves == 0) {
+    /* Exception-handle the case where we found an active task with no cells
+     * that need interacting. This can happen for a pair task when either one
+     * or both cells involved are active, but their respective leaf cells are
+     * too far apart to actually interact with each other.
+     * However, we can't simply early-exit here: If we're unlucky and have to
+     * launch leftovers currently stored in the buffer, they may never get
+     * launched otherwise. So handle that. */
+
+#ifdef SWIFT_DEBUG_CHECKS
+    if (t->type == task_type_self)
+      error(
+          "Found active self task with zero interactions. "
+          "Could be benign, investigate!"
+          );
+#endif
+
+    /* Let others touch data while we're doing GPU computations.
+     * We need this task's data released for the unpacking procedure: If
+     * there is another task in the list we're offloading which requires data
+     * of a cell that this current task is locking, then we'll deadlock.
+     * In the case where we're not launching leftovers, then we'd need to
+     * unlock the task anyway before returning.*/
+    task_unlock(t);
+
+    if (md->launch_leftovers && md->n_leaves_packed > 0) {
+      /* Okay, we have work to do. */
+
+      /* Go straight to launching. */
+      if (t->subtype == task_subtype_gpu_density) {
+
+        runner_gpu_launch_density(r, buf, stream, d_a, d_H);
+        runner_gpu_unpack_density(r, s, buf, /*npacked=*/0);
+
+      } else if (t->subtype == task_subtype_gpu_gradient) {
+
+        runner_gpu_launch_gradient(r, buf, stream, d_a, d_H);
+        runner_gpu_unpack_gradient(r, s, buf, /*npacked=*/0);
+
+      } else if (t->subtype == task_subtype_gpu_force) {
+
+        runner_gpu_launch_force(r, buf, stream, d_a, d_H);
+        runner_dopair_gpu_unpack_force(r, s, buf, /*npacked=*/0);
+
+      }
+#ifdef SWIFT_DEBUG_CHECKS
+      else {
+        error("Unknown task subtype %s", subtaskID_names[t->subtype]);
+      }
+#endif
+
+      /* We have launched, finished all leaf cell pairs, and are done. */
+      /* Reset all buffers and counters. */
+      gpu_pack_metadata_reset(md, /*reset_leaves_lists=*/1);
+      gpu_data_buffers_reset(buf);
+      md->launch_leftovers = 0;
+      md->launch = 0;
+
+    } else {
+
+      /* No work left for this task, close it up. */
+      scheduler_enqueue_dependencies(s, t);
+
+      /* Tell the scheduler's bookkeeping that this task is done */
+      pthread_mutex_lock(&s->sleep_mutex);
+      atomic_dec(&s->waiting);
+      pthread_cond_broadcast(&s->sleep_cond);
+      pthread_mutex_unlock(&s->sleep_mutex);
+
+      /* Mark the task as done. */
+      t->skip = 1;
+    }
+
+    /* We're done here. */
+    return;
+  }
 
   /* How many leaf cell interactions do we want to offload at once? */
   const int target_n_leaves = md->params.pack_size;
 
-  /* Counter for how many leaf cells  of this task we've packed */
+  /* Counter for how many leaf cells of this task we've packed */
   int npacked = 0;
 
-  /* TODO: @Abouzied Please document what is happening here, this looks very
-   * important and scary. Why does this need to happen here, and not
-   * earlier/later? */
-  cell_unlocktree(t->ci);
-  if (t->cj != NULL) cell_unlocktree(t->cj);
+  /* Is this task's cell data currently unlocked? */
+  char unlocked = 0;
 
-  /* Now we go on to pack the particle data into the buffers. If we find enough
-   * data (leaf cell pairs) for an offload, we launch. If there are leaf cell
-   * pairs to pack after the launch, we pack those too after the launch and
-   * unpacking is complete. By the end, all data will have been packed and some
-   * of it (possibly all of it) will have been solved on the GPU already. */
+  /* Main loop for default scenario: We have a task with cells that need to be
+   * packed, transferred, solved, and unpacked. If we find enough data (leaf
+   * cell pairs) for an offload, we launch. If there are leaf cell pairs to
+   * pack after the launch, we pack those too after the launch and unpacking is
+   * complete. By the end, all data will have been packed and some of it
+   * (possibly all of it) will have been solved on the GPU already. */
   while (npacked < md->task_n_leaves) {
 
     /* Inside this loop, we're always working on the last task in our list. But
      * if we launch within this loop, we will shift data back to index 0
      * afterwards, so read the correct up-to-date task index here each time. */
     tind = md->tasks_in_list - 1;
+
+    /* Lock this task's cell data. */
+    if (unlocked) {
+      /* Spin until you get the lock. */
+      while (task_lock(t) != 1){};
+      unlocked = 0;
+    }
 
 #ifdef SWIFT_DEBUG_CHECKS
     if (md->n_leaves_packed >= md->params.leaf_buffer_size)
@@ -599,6 +693,13 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
      * remaining leaves? */
     if (md->launch ||
         (md->launch_leftovers && (npacked == md->task_n_leaves))) {
+
+      /* Let others touch data while we're doing GPU computations.
+       * We need this task's data released for the unpacking procedure: If
+       * there is another task in the list we're offloading which requires data
+       * of a cell that this current task is locking, then we'll deadlock. */
+      task_unlock(t);
+      unlocked = 1;
 
       if (t->subtype == task_subtype_gpu_density) {
 
@@ -695,6 +796,11 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
     } /* if launch or launch_leftovers */
   } /* while npacked < md->task_n_leaves */
 
+  /* We're done with this task's data: Everything we'll need has been copied
+   * into buffers. So we can release the cell locks now. */
+  if (!unlocked) task_unlock(t);
+
+  /* Reset flags too. */
   md->launch_leftovers = 0;
   md->launch = 0;
 }
@@ -724,11 +830,9 @@ static void runner_doself_gpu_density(struct runner *r, struct scheduler *s,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
@@ -759,11 +863,9 @@ static void runner_doself_gpu_gradient(struct runner *r, struct scheduler *s,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
@@ -794,12 +896,9 @@ static void runner_doself_gpu_force(struct runner *r, struct scheduler *s,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
-
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
 }
@@ -833,11 +932,9 @@ static void runner_dopair_gpu_density(const struct runner *r,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
@@ -872,11 +969,9 @@ static void runner_dopair_gpu_gradient(const struct runner *r,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
@@ -910,11 +1005,9 @@ static void runner_dopair_gpu_force(const struct runner *r, struct scheduler *s,
   /* Check to see if this is the last task in the queue. If so, set
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
-  lock_lock(&s->queues[qid].lock);
-  s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]--;
-  if (s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force] < 1)
-    buf->md.launch_leftovers = 1;
-  (void)lock_unlock(&s->queues[qid].lock);
+  /* atomic_dec returns previously held value; So subtract 1 from it again */
+  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
+  if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);

--- a/src/runner_doiact_functions_hydro_gpu.h
+++ b/src/runner_doiact_functions_hydro_gpu.h
@@ -489,7 +489,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
   int *task_first_packed_leaf = md->task_first_packed_leaf;
   int *task_last_packed_leaf = md->task_last_packed_leaf;
 
-  /* Any work here? */
+  /* Should we early exit? */
   if ((md->task_n_leaves == 0) &&
       (!md->launch_leftovers ||
        (md->launch_leftovers && md->n_leaves_packed == 0))) {
@@ -539,8 +539,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
 
 #ifdef SWIFT_DEBUG_CHECKS
   /* Check whether we'll be writing out of bounds. Allow for the special case
-   * where we find a task with zero leaf cell pair interactions (see
-   * explanation further below) */
+   * where we find a task with zero leaf cell pair interactions */
   if (tind > md->params.pack_size ||
       ((tind == md->params.pack_size && md->task_n_leaves != 0)))
     error(

--- a/src/runner_doiact_functions_hydro_gpu.h
+++ b/src/runner_doiact_functions_hydro_gpu.h
@@ -490,7 +490,9 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
   int *task_last_packed_leaf = md->task_last_packed_leaf;
 
   /* Any work here? */
-  if ((md->task_n_leaves == 0) && (!md->launch_leftovers || (md->launch_leftovers && md->n_leaves_packed == 0))) {
+  if ((md->task_n_leaves == 0) &&
+      (!md->launch_leftovers ||
+       (md->launch_leftovers && md->n_leaves_packed == 0))) {
     /* Exception-handle the case where we found an active task with no cells
      * that need interacting. This can happen for a pair task when either one
      * or both cells involved are active, but their respective leaf cells are
@@ -540,7 +542,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
    * where we find a task with zero leaf cell pair interactions (see
    * explanation further below) */
   if (tind > md->params.pack_size ||
-      ((tind == md->params.pack_size && md->task_n_leaves != 0 )))
+      ((tind == md->params.pack_size && md->task_n_leaves != 0)))
     error(
         "Runner %d: Writing out of task_list array bounds: "
         "%d/%d, n_leaves_packed=%d, task_n_leaves=%d",
@@ -585,9 +587,10 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
   char unlocked = 0;
 
   /* Do we have a task with no active cells, but are launching leftovers? */
-  char launch_empty_task_leftovers = (md->task_n_leaves == 0) && md->launch_leftovers;
+  char launch_empty_task_leftovers =
+      (md->task_n_leaves == 0) && md->launch_leftovers;
 
-   /* Now we go on to pack the particle data into the buffers. If we find enough
+  /* Now we go on to pack the particle data into the buffers. If we find enough
    * data (leaf cell pairs) for an offload, we launch. If there are leaf cell
    * pairs to pack after the launch, we pack those too after the launch and
    * unpacking is complete. By the end, all data will have been packed and some
@@ -605,7 +608,8 @@ __attribute__((always_inline)) INLINE static void runner_gpu_pack_and_launch(
     /* Lock this task's cell data. */
     if (unlocked) {
       /* Spin until you get the lock. */
-      while (task_lock(t) != 1){};
+      while (task_lock(t) != 1) {
+      };
       unlocked = 0;
     }
 
@@ -801,7 +805,9 @@ static void runner_doself_gpu_density(struct runner *r, struct scheduler *s,
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) -
+      1;
   if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
@@ -834,7 +840,9 @@ static void runner_doself_gpu_gradient(struct runner *r, struct scheduler *s,
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) -
+      1;
   if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
@@ -867,7 +875,8 @@ static void runner_doself_gpu_force(struct runner *r, struct scheduler *s,
    * launch_leftovers to 1 and pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
   if (count < 1) buf->md.launch_leftovers = 1;
   /* pack the data and run, if enough data has been gathered */
   runner_gpu_pack_and_launch(r, s, buf, t, stream, d_a, d_H);
@@ -903,7 +912,9 @@ static void runner_dopair_gpu_density(const struct runner *r,
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]) -
+      1;
   if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
@@ -940,7 +951,9 @@ static void runner_dopair_gpu_gradient(const struct runner *r,
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]) -
+      1;
   if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */
@@ -976,7 +989,8 @@ static void runner_dopair_gpu_force(const struct runner *r, struct scheduler *s,
    * launch_leftovers to 1 to pack and launch on GPU */
   unsigned int qid = r->qid;
   /* atomic_dec returns previously held value; So subtract 1 from it again */
-  int count = atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
+  int count =
+      atomic_dec(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]) - 1;
   if (count < 1) buf->md.launch_leftovers = 1;
 
   /* pack the data and run, if enough data has been gathered */

--- a/src/runner_gpu_pack_functions.h
+++ b/src/runner_gpu_pack_functions.h
@@ -242,8 +242,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_unpack(
       struct task *t = md->task_list[tid];
 
       /* Can we get the locks? */
-      if (task_lock(t) == 0){
-      }
+      if (task_lock(t) == 0) continue;
 
       /* We got it! Mark that. */
       task_unpacked[tid] = 1;

--- a/src/runner_gpu_pack_functions.h
+++ b/src/runner_gpu_pack_functions.h
@@ -350,7 +350,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_unpack(
        * completed. */
 
       /* schedule my dependencies */
-      enqueue_dependencies(s, md->task_list[tid]);
+      scheduler_enqueue_dependencies(s, md->task_list[tid]);
 
       /* Tell the scheduler's bookkeeping that this task is done */
       pthread_mutex_lock(&s->sleep_mutex);

--- a/src/runner_gpu_pack_functions.h
+++ b/src/runner_gpu_pack_functions.h
@@ -341,7 +341,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_unpack(
        * completed. */
 
       /* schedule my dependencies */
-      scheduler_enqueue_dependencies(s, md->task_list[tid]);
+      scheduler_enqueue_dependencies(s, t);
 
       /* Tell the scheduler's bookkeeping that this task is done */
       pthread_mutex_lock(&s->sleep_mutex);
@@ -350,7 +350,7 @@ __attribute__((always_inline)) INLINE static void runner_gpu_unpack(
       pthread_mutex_unlock(&s->sleep_mutex);
 
       /* Mark the task as done. */
-      md->task_list[tid]->skip = 1;
+      t->skip = 1;
 
     } /* Loop over tasks in list */
   } /* While there are unpacked tasks */

--- a/src/runner_main.c
+++ b/src/runner_main.c
@@ -333,7 +333,7 @@ void *runner_main(void *data) {
           runner_do_hydro_sort(
               r, ci, t->flags,
               ci->hydro.dx_max_sort_old > space_maxreldx * ci->dmin,
-              /*lock=*/0, /*rt_requests_sorts=*/1, /*clock=*/1);
+              /*lock=*/0, /*rt_requests_sort=*/1, /*clock=*/1);
           /* Reset the sort flags as our work here is done. */
           t->flags = 0;
           break;

--- a/src/runner_main.c
+++ b/src/runner_main.c
@@ -333,7 +333,7 @@ void *runner_main(void *data) {
           runner_do_hydro_sort(
               r, ci, t->flags,
               ci->hydro.dx_max_sort_old > space_maxreldx * ci->dmin,
-              /*lock=*/0, /*rt_requests_sort=*/1, /*clock=*/1);
+              /*lock=*/0, /*rt_requests_sorts=*/1, /*clock=*/1);
           /* Reset the sort flags as our work here is done. */
           t->flags = 0;
           break;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -2767,37 +2767,12 @@ void scheduler_enqueue(struct scheduler *s, struct task *t) {
 
 #if defined(WITH_CUDA) || defined(WITH_HIP)
     /* A. Nasar: Increment counters required for the pack tasks */
-    /* TODO: COMBINE THESE TWO BRANCHES */
-    if (t->type == task_type_self) {
-      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0) {
-       */
-      if (t->subtype == task_subtype_gpu_density) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]);
-        /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count
-         * > 0) { */
-      } else if (t->subtype == task_subtype_gpu_force) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]);
-        /* } else if (t->subtype == task_subtype_gpu_gradient &&
-         * t->ci->hydro.count > 0) { */
-      } else if (t->subtype == task_subtype_gpu_gradient) {
-        atomic_inc(
-            &s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
-      }
-    } else if (t->type == task_type_pair) {
-      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0 &&
-       * t->cj->hydro.count > 0) { */
-      if (t->subtype == task_subtype_gpu_density) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]);
-        /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count
-         * > 0 && t->cj->hydro.count > 0) { */
-      } else if (t->subtype == task_subtype_gpu_force) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]);
-        /* } else if (t->subtype == task_subtype_gpu_gradient &&
-         * t->ci->hydro.count > 0 && t->cj->hydro.count > 0) { */
-      } else if (t->subtype == task_subtype_gpu_gradient) {
-        atomic_inc(
-            &s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
-      }
+    if (t->subtype == task_subtype_gpu_density) {
+      atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]);
+    } else if (t->subtype == task_subtype_gpu_force) {
+      atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]);
+    } else if (t->subtype == task_subtype_gpu_gradient) {
+      atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
     }
 #endif
   }

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -2769,27 +2769,34 @@ void scheduler_enqueue(struct scheduler *s, struct task *t) {
     /* A. Nasar: Increment counters required for the pack tasks */
     /* TODO: COMBINE THESE TWO BRANCHES */
     if (t->type == task_type_self) {
-      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0) { */
+      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0) {
+       */
       if (t->subtype == task_subtype_gpu_density) {
         atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]);
-      /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count > 0) { */
+        /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count
+         * > 0) { */
       } else if (t->subtype == task_subtype_gpu_force) {
         atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]);
-      /* } else if (t->subtype == task_subtype_gpu_gradient && t->ci->hydro.count > 0) { */
+        /* } else if (t->subtype == task_subtype_gpu_gradient &&
+         * t->ci->hydro.count > 0) { */
       } else if (t->subtype == task_subtype_gpu_gradient) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
+        atomic_inc(
+            &s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
       }
-    }
-    else if (t->type == task_type_pair) {
-      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0 && t->cj->hydro.count > 0) { */
+    } else if (t->type == task_type_pair) {
+      /* if (t->subtype == task_subtype_gpu_density && t->ci->hydro.count > 0 &&
+       * t->cj->hydro.count > 0) { */
       if (t->subtype == task_subtype_gpu_density) {
         atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_density]);
-      /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count > 0 && t->cj->hydro.count > 0) { */
+        /* } else if (t->subtype == task_subtype_gpu_force && t->ci->hydro.count
+         * > 0 && t->cj->hydro.count > 0) { */
       } else if (t->subtype == task_subtype_gpu_force) {
         atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_force]);
-      /* } else if (t->subtype == task_subtype_gpu_gradient && t->ci->hydro.count > 0 && t->cj->hydro.count > 0) { */
+        /* } else if (t->subtype == task_subtype_gpu_gradient &&
+         * t->ci->hydro.count > 0 && t->cj->hydro.count > 0) { */
       } else if (t->subtype == task_subtype_gpu_gradient) {
-        atomic_inc(&s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
+        atomic_inc(
+            &s->queues[qid].gpu_tasks_left[gpu_task_type_hydro_gradient]);
       }
     }
 #endif

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -290,6 +290,7 @@ void scheduler_init(struct scheduler *s, struct space *space, int nr_tasks,
 struct task *scheduler_gettask(struct scheduler *s, int qid,
                                const struct task *prev);
 void scheduler_enqueue(struct scheduler *s, struct task *t);
+void scheduler_enqueue_dependencies(struct scheduler *s, struct task *t);
 void scheduler_start(struct scheduler *s);
 void scheduler_reset(struct scheduler *s, int nr_tasks);
 void scheduler_ranktasks(struct scheduler *s);
@@ -300,7 +301,6 @@ struct task *scheduler_addtask(struct scheduler *s, enum task_types type,
 void scheduler_splittasks(struct scheduler *s, const int fof_tasks,
                           const int verbose);
 struct task *scheduler_done(struct scheduler *s, struct task *t);
-struct task *scheduler_unlock(struct scheduler *s, struct task *t);
 void scheduler_addunlock(struct scheduler *s, struct task *ta, struct task *tb);
 void scheduler_set_unlocks(struct scheduler *s, struct threadpool *tp);
 void scheduler_dump_queue(struct scheduler *s);
@@ -314,8 +314,5 @@ void scheduler_write_task_level(const struct scheduler *s, int step);
 void scheduler_dump_queues(struct engine *e);
 void scheduler_report_task_times(const struct scheduler *s,
                                  const int nr_threads);
-struct task *enqueue_dependencies(struct scheduler *s, struct task *t);
-struct task *signal_sleeping_runners(struct scheduler *s, struct task *t,
-                                     int tasks_packed);
 
 #endif /* SWIFT_SCHEDULER_H */

--- a/src/task.c
+++ b/src/task.c
@@ -526,7 +526,7 @@ float task_overlap(const struct task *restrict ta,
  *
  * @param t The #task.
  */
-void task_unlock(struct task *t) {
+void task_unlock(const struct task *t) {
 
   const enum task_types type = t->type;
   const enum task_subtypes subtype = t->subtype;
@@ -730,14 +730,17 @@ void task_unlock(struct task *t) {
  * @brief Try to lock the cells associated with this task.
  *
  * @param t the #task.
+ * @return 1 if lock was successfully obtained, 0 otherwise.
  */
 int task_lock(struct task *t) {
 
   const enum task_types type = t->type;
   const enum task_subtypes subtype = t->subtype;
-  struct cell *ci = t->ci, *cj = t->cj;
+  struct cell *ci = t->ci;
+  struct cell *cj = t->cj;
 #ifdef WITH_MPI
-  int res = 0, err = 0;
+  int res = 0;
+  int err = 0;
   MPI_Status stat;
 #endif
 

--- a/src/task.h
+++ b/src/task.h
@@ -251,9 +251,6 @@ struct task {
   /*! Pointers to the cells this task acts upon */
   struct cell *ci, *cj;
 
-  /* TODO: Do we still need this? */
-  int done;
-
   /*! List of tasks unlocked by this one */
   struct task **unlock_tasks;
 
@@ -316,7 +313,7 @@ struct task {
 } SWIFT_STRUCT_ALIGN;
 
 /* Function prototypes. */
-void task_unlock(struct task *t);
+void task_unlock(const struct task *t);
 float task_overlap(const struct task *ta, const struct task *tb);
 int task_lock(struct task *t);
 struct task *task_get_unique_dependent(const struct task *t);


### PR DESCRIPTION
fixing an issue where EAGLE_6 and EAGLE_12 with multi-dt would hang.

Cause was the existence of pair tasks which do not have any active interacting cells. Our bookkeeping was not set up to deal with that scenario.

Code runs now (both with and without gravity), so I think the tasking mechanism may be fine at this point. However, results are not correct. Will need to look into it further in the future.

Builds up on #41 and #42 .