### PR TITLE
re-arranged order of particle quantities for GPU transfer

### DIFF
--- a/src/cuda/gpu_part_structs.h
+++ b/src/cuda/gpu_part_structs.h
@@ -40,7 +40,7 @@ struct gpu_part_send_d {
   /*! Particle position and h -> x, y, z, h */
   float4 x_h;
 
-  /*! Particle predicted velocity and mass -> ux, uy, uz, m */
+  /*! Particle predicted velocity and mass -> vx, vy, vz, m */
   float4 vx_m;
 
   /*! Start and end index of particles to be interacted with in particle
@@ -73,11 +73,11 @@ struct gpu_part_send_g {
   /*! Particle velocity and mass */
   float4 vx_m;
 
-  /*! Particle density alpha visc internal energy u and speed of sound c */
-  float4 rho_avisc_u_c;
+  /*! Particle density, alpha visc, internal energy u, and speed of sound c */
+  float4 u_rho_c_aviscmax;
 
   /*! viscosity information results */
-  float3 vsig_lapu_aviscmax;
+  float3 avisc_vsig_lapu;
 
   /*! Start and end index of particles to be interacted with in particle
    * buffer arrays */
@@ -91,7 +91,7 @@ struct gpu_part_recv_g {
 #ifdef WITH_CUDA
 
   /*! viscosity information results */
-  float3 vsig_lapu_aviscmax;
+  float3 aviscmax_vsig_lapu;
 
 #endif
 };
@@ -109,11 +109,11 @@ struct gpu_part_send_f {
   float4 vx_m;
 
   /*! Variable smoothing length term f, balsara, density, pressure */
-  float4 f_bals_rho_p;
+  float4 u_rho_f_p;
 
   /*! Particle speed of sound, internal energy, alpha constants for
    * viscosity and diffusion */
-  float4 c_u_avisc_adiff;
+  float4 bals_c_avisc_adiff;
 
   /*! Particle timebin, initial value of min neighbour timebin, start
    * and end index of particles to be interacted with in particle buffer
@@ -127,11 +127,11 @@ struct gpu_part_send_f {
 struct gpu_part_recv_f {
 #ifdef WITH_CUDA
 
-  /*! change of u and h with dt, v_sig */
-  float3 udt_hdt_minngbtb;
-
   /*! Particle acceleration vector */
   float3 a_hydro;
+
+  /*! change of u and h with dt, v_sig */
+  float3 udt_hdt_minngbtb;
 
 #endif
 };

--- a/src/hydro/SPHENIX/hydro_part.h
+++ b/src/hydro/SPHENIX/hydro_part.h
@@ -104,35 +104,85 @@ struct xpart {
  */
 struct part {
 
-  /*! Particle unique ID. */
-  long long _id;
-
-  /*! Pointer to corresponding gravity part. */
-  struct gpart *_gpart;
-
   /*! Particle position. */
   double _x[3];
-
-  /*! Particle predicted velocity. */
-  float _v[3];
-
-  /*! Particle acceleration. */
-  float _a_hydro[3];
-
-  /*! Particle mass. */
-  float _mass;
 
   /*! Particle smoothing length. */
   float _h;
 
-  /*! Particle internal energy. */
-  float _u;
+  /*! Particle predicted velocity. */
+  float _v[3];
+
+  /*! Particle mass. */
+  float _mass;
+
+  /*! Particle acceleration. */
+  float _a_hydro[3];
 
   /*! Time derivative of the internal energy. */
   float _u_dt;
 
+  /*! Particle internal energy. */
+  float _u;
+
   /*! Particle density. */
   float _rho;
+
+  /* Store density/force specific stuff. */
+
+  union {
+    /**
+     * @brief Structure for the variables only used in the density loop over
+     * neighbours.
+     *
+     * Quantities in this sub-structure should only be accessed in the density
+     * loop over neighbours and the ghost task.
+     */
+    struct {
+
+      /*! Derivative of density with respect to h */
+      float _rho_dh;
+
+      /*! Neighbour number count. */
+      float _wcount;
+
+      /*! Derivative of the neighbour number with respect to h. */
+      float _wcount_dh;
+
+      /*! Particle velocity curl. */
+      float _rot_v[3];
+
+    } density;
+
+    /**
+     * @brief Structure for the variables only used in the force loop over
+     * neighbours.
+     *
+     * Quantities in this sub-structure should only be accessed in the force
+     * loop over neighbours and the ghost, drift and kick tasks.
+     */
+    struct {
+
+      /*! "Grad h" term -- only partial in P-U */
+      float _f_gradh;
+
+      /*! Particle pressure. */
+      float _pressure;
+
+      /*! Balsara switch */
+      float _balsara;
+
+      /*! Particle soundspeed. */
+      float _soundspeed;
+
+      /*! Maximal alpha (viscosity) over neighbours */
+      float _alpha_visc_max_ngb;
+
+      /*! Time derivative of smoothing length  */
+      float _h_dt;
+
+    } force;
+  };
 
   /* Store viscosity information in a separate struct. */
   struct {
@@ -165,61 +215,11 @@ struct part {
 
   } diffusion;
 
-  /* Store density/force specific stuff. */
+  /*! Particle unique ID. */
+  long long _id;
 
-  union {
-    /**
-     * @brief Structure for the variables only used in the density loop over
-     * neighbours.
-     *
-     * Quantities in this sub-structure should only be accessed in the density
-     * loop over neighbours and the ghost task.
-     */
-    struct {
-
-      /*! Neighbour number count. */
-      float _wcount;
-
-      /*! Derivative of the neighbour number with respect to h. */
-      float _wcount_dh;
-
-      /*! Derivative of density with respect to h */
-      float _rho_dh;
-
-      /*! Particle velocity curl. */
-      float _rot_v[3];
-
-    } density;
-
-    /**
-     * @brief Structure for the variables only used in the force loop over
-     * neighbours.
-     *
-     * Quantities in this sub-structure should only be accessed in the force
-     * loop over neighbours and the ghost, drift and kick tasks.
-     */
-    struct {
-
-      /*! "Grad h" term -- only partial in P-U */
-      float _f_gradh;
-
-      /*! Particle pressure. */
-      float _pressure;
-
-      /*! Particle soundspeed. */
-      float _soundspeed;
-
-      /*! Time derivative of smoothing length  */
-      float _h_dt;
-
-      /*! Balsara switch */
-      float _balsara;
-
-      /*! Maximal alpha (viscosity) over neighbours */
-      float _alpha_visc_max_ngb;
-
-    } force;
-  };
+  /*! Pointer to corresponding gravity part. */
+  struct gpart *_gpart;
 
   /*! Additional data used for adaptive softening */
   struct adaptive_softening_part_data _adaptive_softening_data;


### PR DESCRIPTION
re-order the arrangement of particle member variables and how we transport them to the gpu. Now the order of the gpu_part_structs should match the order of the hydro_part struct.

Also adding back the packing of gradient vars which were forgotten for some unknown reason...